### PR TITLE
[FIXED JENKINS-20263]

### DIFF
--- a/src/main/java/org/jvnet/hudson/plugins/repositoryconnector/aether/Aether.java
+++ b/src/main/java/org/jvnet/hudson/plugins/repositoryconnector/aether/Aether.java
@@ -116,13 +116,14 @@ public class Aether {
                 repoObj.setAuthentication(authentication);
             }
             repoObj.setRepositoryManager(repo.isRepositoryManager());
+            repoObj.setPolicy(true, snapshotPolicy);
+            repoObj.setPolicy(false, releasePolicy);
+            
             if (repoObj.isRepositoryManager()) {
                 // well, in case of repository manager, let's have a look one step deeper
                 // @see org.sonatype.aether.impl.internal.DefaultMetadataResolver#getEnabledSourceRepositories(org.sonatype.aether.repository.RemoteRepository, org.sonatype.aether.metadata.Metadata.Nature)
                 repoObj.setMirroredRepositories(resolveMirrors(repoObj));
             }
-            repoObj.setPolicy(true, snapshotPolicy);
-            repoObj.setPolicy(false, releasePolicy);
             repositories.add(repoObj);
         }
     }


### PR DESCRIPTION
Artifact Resolver does not retrieve the latest version from central Maven Repository
* as #resolveMirrors() currently just copies the repository, we should ensure, that the policies are set BEFORE the copy was made