### PR TITLE
Allow Artifact Deploy step (JENKINS-30554)

### DIFF
--- a/src/main/java/org/jvnet/hudson/plugins/repositoryconnector/Repository.java
+++ b/src/main/java/org/jvnet/hudson/plugins/repositoryconnector/Repository.java
@@ -23,15 +23,17 @@ public class Repository implements Serializable, Comparable {
     final private String user;
     final private String password;
     final private boolean isRepositoryManager;
+    final private boolean allowDeploy;
 
     @DataBoundConstructor
-    public Repository(String id, String type, String url, String user, String password, boolean repositoryManager) {
+    public Repository(String id, String type, String url, String user, String password, boolean repositoryManager, boolean allowDeploy) {
         this.id = id == null ? "central" : id;
         this.type = type == null ? "default" : type;
         this.url = url;
         this.user = user;
         this.password = password;
         this.isRepositoryManager = repositoryManager;
+        this.allowDeploy = allowDeploy;
     }
 
     /**
@@ -127,6 +129,13 @@ public class Repository implements Serializable, Comparable {
      */
     public boolean isRepositoryManager() {
         return isRepositoryManager;
+    }
+
+    /**
+     * @return the allowDeploy
+     */
+    public boolean allowDeploy() {
+        return allowDeploy;
     }
 
     public int compareTo(Object o) {

--- a/src/main/java/org/jvnet/hudson/plugins/repositoryconnector/Repository.java
+++ b/src/main/java/org/jvnet/hudson/plugins/repositoryconnector/Repository.java
@@ -129,7 +129,7 @@ public class Repository implements Serializable, Comparable {
         return isRepositoryManager;
     }
 
-        public int compareTo(Object o) {
-            return id.compareTo(((Repository)o).getId());
-        }
+    public int compareTo(Object o) {
+        return id.compareTo(((Repository)o).getId());
+    }
 }

--- a/src/main/java/org/jvnet/hudson/plugins/repositoryconnector/RepositoryConfiguration.java
+++ b/src/main/java/org/jvnet/hudson/plugins/repositoryconnector/RepositoryConfiguration.java
@@ -112,7 +112,6 @@ public class RepositoryConfiguration extends GlobalConfiguration implements Seri
         return result;
     }
 
-
     public Collection<Repository> getRepos() {
         List<Repository> r = new ArrayList<Repository>();
         r.addAll(repos.values());
@@ -120,6 +119,7 @@ public class RepositoryConfiguration extends GlobalConfiguration implements Seri
         log.fine("repos=" + r);
         return r;
     }
+
     public Map<String, Repository> getRepositoryMap() {
         log.fine("reposmap=" + repos);
         return repos;

--- a/src/main/java/org/jvnet/hudson/plugins/repositoryconnector/RepositoryConfiguration.java
+++ b/src/main/java/org/jvnet/hudson/plugins/repositoryconnector/RepositoryConfiguration.java
@@ -32,7 +32,7 @@ public class RepositoryConfiguration extends GlobalConfiguration implements Seri
 
     private static final Map<String, Repository> DEFAULT_REPOS = new HashMap<String, Repository>();
     static {
-        DEFAULT_REPOS.put("central", new Repository("central", "default", "http://repo1.maven.org/maven2", null, null, false));
+        DEFAULT_REPOS.put("central", new Repository("central", "default", "http://repo1.maven.org/maven2", null, null, false, true));
     }
 
     private final Map<String, Repository> repos = new HashMap<String, Repository>();
@@ -110,6 +110,18 @@ public class RepositoryConfiguration extends GlobalConfiguration implements Seri
             result.mkdirs();
         }
         return result;
+    }
+
+    public Collection<Repository> getDeployableRepos() {
+        List<Repository> r = new ArrayList<Repository>();
+        for (Repository repo : repos.values()) {
+            if (repo.allowDeploy()) {
+                r.add(repo);
+            }
+        }
+        Collections.sort(r);
+        log.fine("repos=" + r);
+        return r;
     }
 
     public Collection<Repository> getRepos() {

--- a/src/main/java/org/jvnet/hudson/plugins/repositoryconnector/aether/Aether.java
+++ b/src/main/java/org/jvnet/hudson/plugins/repositoryconnector/aether/Aether.java
@@ -61,7 +61,7 @@ import org.sonatype.aether.util.repository.DefaultProxySelector;
 import org.sonatype.aether.version.Version;
 
 public class Aether {
-        private static final Logger log = Logger.getLogger(Aether.class.getName());
+    private static final Logger log = Logger.getLogger(Aether.class.getName());
 
     private final List<RemoteRepository> repositories = new ArrayList<RemoteRepository>();
     private final RepositorySystem repositorySystem;
@@ -74,9 +74,9 @@ public class Aether {
     public String releaseChecksumPolicy;
 
     public Aether(Collection<Repository> remoteRepositories, File localRepository) {
-            this(remoteRepositories, localRepository, null, false, RepositoryPolicy.UPDATE_POLICY_NEVER, 
-                    RepositoryPolicy.CHECKSUM_POLICY_IGNORE, RepositoryPolicy.UPDATE_POLICY_NEVER, RepositoryPolicy.CHECKSUM_POLICY_IGNORE);
-        }
+        this(remoteRepositories, localRepository, null, false, RepositoryPolicy.UPDATE_POLICY_NEVER, 
+                RepositoryPolicy.CHECKSUM_POLICY_IGNORE, RepositoryPolicy.UPDATE_POLICY_NEVER, RepositoryPolicy.CHECKSUM_POLICY_IGNORE);
+    }
 
     public Aether(Collection<Repository> remoteRepositories, File localRepository, PrintStream logger, boolean extendedLogging,
             String snapshotUpdatePolicy, String snapshotChecksumPolicy, String releaseUpdatePolicy, String releaseChecksumPolicy) {
@@ -127,35 +127,35 @@ public class Aether {
             repositories.add(repoObj);
         }
     }
-    
-	private void addProxySelectorIfNecessary(DefaultRepositorySystemSession repositorySession) {
-		Jenkins jenkins = Jenkins.getInstance();
-		if (jenkins.proxy != null && StringUtils.isNotBlank(jenkins.proxy.name)) {
-			DefaultProxySelector proxySelector = new DefaultProxySelector();
-			Authentication authenticator = new Authentication(jenkins.proxy.getUserName(), jenkins.proxy.getPassword());
 
-			Proxy httpProxy = new Proxy("http", jenkins.proxy.name, jenkins.proxy.port, authenticator);
-			Proxy httpsProxy = new Proxy("https", jenkins.proxy.name, jenkins.proxy.port, authenticator);
+    private void addProxySelectorIfNecessary(DefaultRepositorySystemSession repositorySession) {
+        Jenkins jenkins = Jenkins.getInstance();
+        if (jenkins.proxy != null && StringUtils.isNotBlank(jenkins.proxy.name)) {
+            DefaultProxySelector proxySelector = new DefaultProxySelector();
+            Authentication authenticator = new Authentication(jenkins.proxy.getUserName(), jenkins.proxy.getPassword());
 
-			String nonProxySettings = convertHudsonNonProxyToJavaNonProxy(jenkins.proxy.noProxyHost);
+            Proxy httpProxy = new Proxy("http", jenkins.proxy.name, jenkins.proxy.port, authenticator);
+            Proxy httpsProxy = new Proxy("https", jenkins.proxy.name, jenkins.proxy.port, authenticator);
 
-			proxySelector.add(httpProxy, nonProxySettings);
-			proxySelector.add(httpsProxy, nonProxySettings);
+            String nonProxySettings = convertHudsonNonProxyToJavaNonProxy(jenkins.proxy.noProxyHost);
 
-			log.log(Level.FINE, "Setting proxy for Aether: host={0}, port={1}, user={2}, password=******, nonProxyHosts={3}",
-					new Object[] { jenkins.proxy.name, jenkins.proxy.port, jenkins.proxy.getUserName(), nonProxySettings });
-			repositorySession.setProxySelector(proxySelector);
-		}
-	}
+            proxySelector.add(httpProxy, nonProxySettings);
+            proxySelector.add(httpsProxy, nonProxySettings);
 
-	public String convertHudsonNonProxyToJavaNonProxy(String hudsonNonProxy) {
-        if (StringUtils.isEmpty(hudsonNonProxy)) {
-            return "";
+            log.log(Level.FINE, "Setting proxy for Aether: host={0}, port={1}, user={2}, password=******, nonProxyHosts={3}",
+                            new Object[] { jenkins.proxy.name, jenkins.proxy.port, jenkins.proxy.getUserName(), nonProxySettings });
+            repositorySession.setProxySelector(proxySelector);
         }
-		String[] nonProxyArray = hudsonNonProxy.split("[ \t\n,|]+");
-		String nonProxyOneLine = StringUtils.join(nonProxyArray, '|');
-		return nonProxyOneLine;
-	}
+    }
+
+    public String convertHudsonNonProxyToJavaNonProxy(String hudsonNonProxy) {
+    if (StringUtils.isEmpty(hudsonNonProxy)) {
+        return "";
+    }
+        String[] nonProxyArray = hudsonNonProxy.split("[ \t\n,|]+");
+        String nonProxyOneLine = StringUtils.join(nonProxyArray, '|');
+        return nonProxyOneLine;
+    }
 
     /**
      * Resolve mirrors configured in this repository... Or fake it...
@@ -213,13 +213,13 @@ public class Aether {
         RepositorySystemSession session = newSession();
         Artifact artifact = new DefaultArtifact(groupId, artifactId, null, null, "[0,)");
 
-                VersionRangeRequest rangeRequest = new VersionRangeRequest();
-                rangeRequest.setArtifact( artifact );
-                rangeRequest.setRepositories( repositories );
+        VersionRangeRequest rangeRequest = new VersionRangeRequest();
+        rangeRequest.setArtifact( artifact );
+        rangeRequest.setRepositories( repositories );
 
-                VersionRangeResult rangeResult = repositorySystem.resolveVersionRange( session, rangeRequest );
+        VersionRangeResult rangeResult = repositorySystem.resolveVersionRange( session, rangeRequest );
 
-                return rangeResult.getVersions();
+        return rangeResult.getVersions();
     }
 
     public void install(Artifact artifact, Artifact pom) throws InstallationException {
@@ -238,9 +238,9 @@ public class Aether {
         repoObj.setRepositoryManager(repository.isRepositoryManager());
         final String user = repository.getUser();
         if (!StringUtils.isBlank(user)) {
-                        if (logger != null) {
-                            logger.println("INFO: set authentication for " + user);
-                        }
+            if (logger != null) {
+                logger.println("INFO: set authentication for " + user);
+            }
             Authentication authentication = new Authentication(user, repository.getPassword());
             repoObj.setAuthentication(authentication);
         }

--- a/src/main/resources/org/jvnet/hudson/plugins/repositoryconnector/ArtifactDeployer/config.jelly
+++ b/src/main/resources/org/jvnet/hudson/plugins/repositoryconnector/ArtifactDeployer/config.jelly
@@ -1,81 +1,81 @@
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
-	xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+    xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
 
-	<f:entry title="${%EnableRepositoryLogging}" description="${%EnableRepositoryLoggingDescription}">
-		<f:checkbox name="enableRepoLogging" checked="${instance.enableRepoLogging()}" />
-	</f:entry>
+    <f:entry title="${%EnableRepositoryLogging}" description="${%EnableRepositoryLoggingDescription}">
+        <f:checkbox name="enableRepoLogging" checked="${instance.enableRepoLogging()}" />
+    </f:entry>
 
-	<f:entry title="${%Repository}">
-		<select class="setting-input" name="repoId"
-			description="${%RepositoryDescription}">
-			<j:forEach var="repo" items="${instance.repos}">
-				<f:option selected="${instance.repoId==repo.id}" value="${repo.id}">${repo.id}
-					- ${repo.url}</f:option>
-			</j:forEach>
-		</select>
-	</f:entry>
+    <f:entry title="${%Repository}">
+        <select class="setting-input" name="repoId"
+            description="${%RepositoryDescription}">
+            <j:forEach var="repo" items="${instance.repos}">
+                <f:option selected="${instance.repoId==repo.id}" value="${repo.id}">${repo.id}
+                    - ${repo.url}</f:option>
+            </j:forEach>
+        </select>
+    </f:entry>
 
-	<f:entry title="${%SnapshotRepository}">
-		<select class="setting-input" name="snapshotRepoId"
-			description="${%SnapshotRepositoryDescription}">
-			<j:forEach var="repo" items="${instance.repos}">
-				<f:option selected="${instance.snapshotRepoId==repo.id}"
-					value="${repo.id}">${repo.id} - ${repo.url}</f:option>
-			</j:forEach>
-		</select>
-	</f:entry>
+    <f:entry title="${%SnapshotRepository}">
+        <select class="setting-input" name="snapshotRepoId"
+            description="${%SnapshotRepositoryDescription}">
+            <j:forEach var="repo" items="${instance.repos}">
+                <f:option selected="${instance.snapshotRepoId==repo.id}"
+                    value="${repo.id}">${repo.id} - ${repo.url}</f:option>
+            </j:forEach>
+        </select>
+    </f:entry>
 
 
-	<f:optionalBlock name="overwriteSecurity" title="${%OverwritePermissions}"
-		checked="${instance.isOverwriteSecurity()}" help="/plugin/repository-connector/help-permissions.html">
-		<f:entry title="${%User}">
-			<f:textbox name="user" value="${instance.getUserName()}" />
-		</f:entry>
+    <f:optionalBlock name="overwriteSecurity" title="${%OverwritePermissions}"
+        checked="${instance.isOverwriteSecurity()}" help="/plugin/repository-connector/help-permissions.html">
+        <f:entry title="${%User}">
+            <f:textbox name="user" value="${instance.getUserName()}" />
+        </f:entry>
 
-		<f:entry title="${%Password}">
-			<f:password name="password" value="${instance.getPassword()}" />
-		</f:entry>
-	</f:optionalBlock>
+        <f:entry title="${%Password}">
+            <f:password name="password" value="${instance.getPassword()}" />
+        </f:entry>
+    </f:optionalBlock>
 
-	<f:entry title="${Artifacts}">
-		<f:repeatable var="artifact" items="${instance.artifacts}"
-			name="artifacts" noAddButton="true" minimum="1">
-			<table width="100%">
+    <f:entry title="${Artifacts}">
+        <f:repeatable var="artifact" items="${instance.artifacts}"
+            name="artifacts" noAddButton="true" minimum="1">
+            <table width="100%">
 
-				<f:entry title="${%GroupId}">
-					<f:textbox name="groupId" value="${artifact.groupId}" />
-				</f:entry>
+                <f:entry title="${%GroupId}">
+                    <f:textbox name="groupId" value="${artifact.groupId}" />
+                </f:entry>
 
-				<f:entry title="${%ArtifactId}">
-					<f:textbox name="artifactId" value="${artifact.artifactId}" />
-				</f:entry>
+                <f:entry title="${%ArtifactId}">
+                    <f:textbox name="artifactId" value="${artifact.artifactId}" />
+                </f:entry>
 
-				<f:entry title="${%Version}">
-					<f:textbox name="version" value="${artifact.version}" />
-				</f:entry>
+                <f:entry title="${%Version}">
+                    <f:textbox name="version" value="${artifact.version}" />
+                </f:entry>
 
-				<f:entry title="${%Classifier}">
-					<f:textbox name="classifier" value="${artifact.classifier}" />
-				</f:entry>
+                <f:entry title="${%Classifier}">
+                    <f:textbox name="classifier" value="${artifact.classifier}" />
+                </f:entry>
 
-				<f:entry title="${%Packaging}">
-					<f:textbox name="extension" value="${artifact.extension}" />
-				</f:entry>
+                <f:entry title="${%Packaging}">
+                    <f:textbox name="extension" value="${artifact.extension}" />
+                </f:entry>
 
-				<f:entry title="${%File}" description="${%FileDescription}">
-					<f:textbox name="targetFileName" value="${artifact.targetFileName}" />
-				</f:entry>
+                <f:entry title="${%File}" description="${%FileDescription}">
+                    <f:textbox name="targetFileName" value="${artifact.targetFileName}" />
+                </f:entry>
 
-				<f:entry>
-					<div align="right">
-						<input type="button" value="${%AddArtifact}" class="repeatable-add show-if-last" />
-						<input type="button" value="${%Delete}"
-							class="repeatable-delete show-if-not-only" style="margin-left: 1em;" />
-					</div>
-				</f:entry>
-			</table>
-		</f:repeatable>
-	</f:entry>
+                <f:entry>
+                    <div align="right">
+                        <input type="button" value="${%AddArtifact}" class="repeatable-add show-if-last" />
+                        <input type="button" value="${%Delete}"
+                            class="repeatable-delete show-if-not-only" style="margin-left: 1em;" />
+                    </div>
+                </f:entry>
+            </table>
+        </f:repeatable>
+    </f:entry>
 
 
 </j:jelly>

--- a/src/main/resources/org/jvnet/hudson/plugins/repositoryconnector/ArtifactDeployer/config.jelly
+++ b/src/main/resources/org/jvnet/hudson/plugins/repositoryconnector/ArtifactDeployer/config.jelly
@@ -8,19 +8,19 @@
     <f:entry title="${%Repository}">
         <select class="setting-input" name="repoId"
             description="${%RepositoryDescription}">
-            <j:forEach var="repo" items="${instance.repos}">
-                <f:option selected="${instance.repoId==repo.id}" value="${repo.id}">${repo.id}
-                    - ${repo.url}</f:option>
+            <j:forEach var="repo" items="${descriptor.repos}">
+                <f:option selected="${instance.repoId==repo.id}"
+                                          value="${repo.id}">${repo.id} [ ${repo.url} ]</f:option>
             </j:forEach>
         </select>
-    </f:entry>
+        </f:entry>
 
     <f:entry title="${%SnapshotRepository}">
         <select class="setting-input" name="snapshotRepoId"
             description="${%SnapshotRepositoryDescription}">
-            <j:forEach var="repo" items="${instance.repos}">
+            <j:forEach var="repo" items="${descriptor.repos}">
                 <f:option selected="${instance.snapshotRepoId==repo.id}"
-                    value="${repo.id}">${repo.id} - ${repo.url}</f:option>
+                    value="${repo.id}">${repo.id} [ ${repo.url} ]</f:option>
             </j:forEach>
         </select>
     </f:entry>

--- a/src/main/resources/org/jvnet/hudson/plugins/repositoryconnector/ArtifactDeployer/pom.tmpl
+++ b/src/main/resources/org/jvnet/hudson/plugins/repositoryconnector/ArtifactDeployer/pom.tmpl
@@ -1,10 +1,10 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-	<modelVersion>4.0.0</modelVersion>
+    <modelVersion>4.0.0</modelVersion>
 
-	<groupId>GROUPID</groupId>
-	<artifactId>ARTIFACTID</artifactId>
-	<name>ARTIFACTID</name>
-	<version>VERSION</version>
-	<packaging>PACKAGING</packaging>
+    <groupId>GROUPID</groupId>
+    <artifactId>ARTIFACTID</artifactId>
+    <name>ARTIFACTID</name>
+    <version>VERSION</version>
+    <packaging>PACKAGING</packaging>
 
 </project>

--- a/src/main/resources/org/jvnet/hudson/plugins/repositoryconnector/ArtifactResolver/config.jelly
+++ b/src/main/resources/org/jvnet/hudson/plugins/repositoryconnector/ArtifactResolver/config.jelly
@@ -1,81 +1,81 @@
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
-	xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+    xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
 
-	<f:entry title="${%FailOnError}"
-		description="${%FailOnErrorDescription}">
-		<f:checkbox name="failOnError" checked="${instance.failOnError()}" />
-	</f:entry>
+    <f:entry title="${%FailOnError}"
+        description="${%FailOnErrorDescription}">
+        <f:checkbox name="failOnError" checked="${instance.failOnError()}" />
+    </f:entry>
 
-	<f:entry title="${%EnableRepositoryLogging}" description="${%EnableRepositoryLoggingDescription}">
-		<f:checkbox name="enableRepoLogging" checked="${instance.enableRepoLogging()}" />
-	</f:entry>
+    <f:entry title="${%EnableRepositoryLogging}" description="${%EnableRepositoryLoggingDescription}">
+        <f:checkbox name="enableRepoLogging" checked="${instance.enableRepoLogging()}" />
+    </f:entry>
 
-	<f:entry title="${%TargetDirectory}">
-		<f:textbox name="targetDirectory" value="${instance.targetDirectory}" />
-	</f:entry>
+    <f:entry title="${%TargetDirectory}">
+        <f:textbox name="targetDirectory" value="${instance.targetDirectory}" />
+    </f:entry>
 
-	<f:entry title="${%ReleaseUpdatePolicy}">
-		<select class="setting-input" name="releaseUpdatePolicy">
-			<f:option selected="${instance.releaseUpdatePolicy=='daily'}"
-				value="never">daily</f:option>
-			<f:option selected="${instance.releaseUpdatePolicy=='never'}"
-				value="never">never</f:option>
-			<f:option selected="${instance.releaseUpdatePolicy=='always'}"
-				value="always">always</f:option>
-		</select>
-	</f:entry>
+    <f:entry title="${%ReleaseUpdatePolicy}">
+        <select class="setting-input" name="releaseUpdatePolicy">
+            <f:option selected="${instance.releaseUpdatePolicy=='daily'}"
+                value="never">daily</f:option>
+            <f:option selected="${instance.releaseUpdatePolicy=='never'}"
+                value="never">never</f:option>
+            <f:option selected="${instance.releaseUpdatePolicy=='always'}"
+                value="always">always</f:option>
+        </select>
+    </f:entry>
 
-	<f:entry title="${%SnapshotUpdatePolicy}">
-		<select class="setting-input" name="snapshotUpdatePolicy">
-			<f:option selected="${instance.snapshotUpdatePolicy=='daily'}"
-				value="never">daily</f:option>
-			<f:option selected="${instance.snapshotUpdatePolicy=='never'}"
-				value="never">never</f:option>
-			<f:option selected="${instance.snapshotUpdatePolicy=='always'}"
-				value="always">always</f:option>
-		</select>
-	</f:entry>
+    <f:entry title="${%SnapshotUpdatePolicy}">
+        <select class="setting-input" name="snapshotUpdatePolicy">
+            <f:option selected="${instance.snapshotUpdatePolicy=='daily'}"
+                value="never">daily</f:option>
+            <f:option selected="${instance.snapshotUpdatePolicy=='never'}"
+                value="never">never</f:option>
+            <f:option selected="${instance.snapshotUpdatePolicy=='always'}"
+                value="always">always</f:option>
+        </select>
+    </f:entry>
 
-	<f:entry title="${%Artifacts}">
-		<f:repeatable var="artifact" items="${instance.artifacts}"
-			name="artifacts" noAddButton="true" minimum="1">
-			<table width="100%">
+    <f:entry title="${%Artifacts}">
+        <f:repeatable var="artifact" items="${instance.artifacts}"
+            name="artifacts" noAddButton="true" minimum="1">
+            <table width="100%">
 
-				<f:entry title="${%GroupId}">
-					<f:textbox name="groupId" value="${artifact.groupId}" />
-				</f:entry>
+                <f:entry title="${%GroupId}">
+                    <f:textbox name="groupId" value="${artifact.groupId}" />
+                </f:entry>
 
-				<f:entry title="${%ArtifactId}">
-					<f:textbox name="artifactId" value="${artifact.artifactId}" />
-				</f:entry>
+                <f:entry title="${%ArtifactId}">
+                    <f:textbox name="artifactId" value="${artifact.artifactId}" />
+                </f:entry>
 
-				<f:entry title="${%Version}">
-					<f:textbox name="version" value="${artifact.version}" />
-				</f:entry>
+                <f:entry title="${%Version}">
+                    <f:textbox name="version" value="${artifact.version}" />
+                </f:entry>
 
-				<f:entry title="${%Classifier}">
-					<f:textbox name="classifier" value="${artifact.classifier}" />
-				</f:entry>
+                <f:entry title="${%Classifier}">
+                    <f:textbox name="classifier" value="${artifact.classifier}" />
+                </f:entry>
 
-				<f:entry title="${%Extension}">
-					<f:textbox name="extension" value="${artifact.extension}"
-						default="jar" />
-				</f:entry>
+                <f:entry title="${%Extension}">
+                    <f:textbox name="extension" value="${artifact.extension}"
+                        default="jar" />
+                </f:entry>
 
-				<f:entry title="${%TargetFilename}"
-					description="${%TargetFilenameDescription}">
-					<f:textbox name="targetFileName" value="${artifact.targetFileName}" />
-				</f:entry>
+                <f:entry title="${%TargetFilename}"
+                    description="${%TargetFilenameDescription}">
+                    <f:textbox name="targetFileName" value="${artifact.targetFileName}" />
+                </f:entry>
 
-				<f:entry>
-					<div align="right">
-						<input type="button" value="${%AddArtifact}" class="repeatable-add show-if-last" />
-						<input type="button" value="${%Delete}"
-							class="repeatable-delete show-if-not-only" style="margin-left: 1em;" />
-					</div>
-				</f:entry>
-			</table>
-		</f:repeatable>
-	</f:entry>
+                <f:entry>
+                    <div align="right">
+                        <input type="button" value="${%AddArtifact}" class="repeatable-add show-if-last" />
+                        <input type="button" value="${%Delete}"
+                            class="repeatable-delete show-if-not-only" style="margin-left: 1em;" />
+                    </div>
+                </f:entry>
+            </table>
+        </f:repeatable>
+    </f:entry>
 
 </j:jelly>

--- a/src/main/resources/org/jvnet/hudson/plugins/repositoryconnector/RepositoryConfiguration/config.jelly
+++ b/src/main/resources/org/jvnet/hudson/plugins/repositoryconnector/RepositoryConfiguration/config.jelly
@@ -1,52 +1,52 @@
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
-	xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-	<f:section title="${%ArtifactResolver}">
+    xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+    <f:section title="${%ArtifactResolver}">
 
-		<f:entry title="${%LocalRepository}"
-			description="${%LocalRepositoryDescription}"
-			help="/plugin/repository-connector/help-globalConfig.html" field="localRepository">
-			<f:textbox name="artifactresolver.localRepository" value="${descriptor.localRepository}" />
-		</f:entry>
+        <f:entry title="${%LocalRepository}"
+            description="${%LocalRepositoryDescription}"
+            help="/plugin/repository-connector/help-globalConfig.html" field="localRepository">
+            <f:textbox name="artifactresolver.localRepository" value="${descriptor.localRepository}" />
+        </f:entry>
 
-		<f:entry title="${%Repositories}"
-			description="${%RepositoriesDescription}">
-			<f:repeatable var="repo" items="${descriptor.repos}"
-				name="artifactresolver.repos" noAddButton="true" minimum="1">
-				<table width="100%">
+        <f:entry title="${%Repositories}"
+            description="${%RepositoriesDescription}">
+            <f:repeatable var="repo" items="${descriptor.repos}"
+                name="artifactresolver.repos" noAddButton="true" minimum="1">
+                <table width="100%">
 
-					<f:entry title="${%RepoId}">
-						<f:textbox name="id" value="${repo.id}" />
-					</f:entry>
+                    <f:entry title="${%RepoId}">
+                        <f:textbox name="id" value="${repo.id}" />
+                    </f:entry>
 
-					<f:entry title="${%RepoType}">
-						<f:textbox name="type" value="${repo.type}" />
-					</f:entry>
-					
-					<f:entry title="${%RepoManager}" description="${%RepoManagerDescription}">
+                    <f:entry title="${%RepoType}">
+                        <f:textbox name="type" value="${repo.type}" />
+                    </f:entry>
+                    
+                    <f:entry title="${%RepoManager}" description="${%RepoManagerDescription}">
                         <f:checkbox name="repositoryManager" checked="${repo.isRepositoryManager()}"/>
                     </f:entry>
 
-					<f:entry title="${%Url}">
-						<f:textbox name="url" value="${repo.url}" />
-					</f:entry>
+                    <f:entry title="${%Url}">
+                        <f:textbox name="url" value="${repo.url}" />
+                    </f:entry>
 
-					<f:entry title="${%User}">
-						<f:textbox name="user" value="${repo.user}" />
-					</f:entry>
+                    <f:entry title="${%User}">
+                        <f:textbox name="user" value="${repo.user}" />
+                    </f:entry>
 
-					<f:entry title="${%Password}">
-						<f:password name="password" value="${repo.password}" />
-					</f:entry>
+                    <f:entry title="${%Password}">
+                        <f:password name="password" value="${repo.password}" />
+                    </f:entry>
 
-					<f:entry>
-						<div align="right">
-							<input type="button" value="${%AddNewRepo}" class="repeatable-add show-if-last" />
-							<input type="button" value="${%Delete}"
-								class="repeatable-delete show-if-not-only" style="margin-left: 1em;" />
-						</div>
-					</f:entry>
-				</table>
-			</f:repeatable>
-		</f:entry>
-	</f:section>
+                    <f:entry>
+                        <div align="right">
+                            <input type="button" value="${%AddNewRepo}" class="repeatable-add show-if-last" />
+                            <input type="button" value="${%Delete}"
+                                class="repeatable-delete show-if-not-only" style="margin-left: 1em;" />
+                        </div>
+                    </f:entry>
+                </table>
+            </f:repeatable>
+        </f:entry>
+    </f:section>
 </j:jelly>

--- a/src/main/resources/org/jvnet/hudson/plugins/repositoryconnector/RepositoryConfiguration/config.jelly
+++ b/src/main/resources/org/jvnet/hudson/plugins/repositoryconnector/RepositoryConfiguration/config.jelly
@@ -21,7 +21,7 @@
                     <f:entry title="${%RepoType}">
                         <f:textbox name="type" value="${repo.type}" />
                     </f:entry>
-                    
+
                     <f:entry title="${%RepoManager}" description="${%RepoManagerDescription}">
                         <f:checkbox name="repositoryManager" checked="${repo.isRepositoryManager()}"/>
                     </f:entry>
@@ -36,6 +36,10 @@
 
                     <f:entry title="${%Password}">
                         <f:password name="password" value="${repo.password}" />
+                    </f:entry>
+
+                    <f:entry title="${%AllowDeploy}" description="${%AllowDeployDescription}">
+                        <f:checkbox name="allowDeploy" checked="${repo.allowDeploy()}"/>
                     </f:entry>
 
                     <f:entry>

--- a/src/main/resources/org/jvnet/hudson/plugins/repositoryconnector/RepositoryConfiguration/config.properties
+++ b/src/main/resources/org/jvnet/hudson/plugins/repositoryconnector/RepositoryConfiguration/config.properties
@@ -10,5 +10,7 @@ RepoManagerDescription=checked if this repository points at a repository manager
 Url=Url
 User=User
 Password=Password
+AllowDeploy=Allow Deploy
+AllowDeployDescription=checked if this repository allows manual deploy via Artifact Deployer post-build action
 AddNewRepo=Add new repository
 Delete=Delete

--- a/src/main/resources/org/jvnet/hudson/plugins/repositoryconnector/RepositoryConfiguration/config_de.properties
+++ b/src/main/resources/org/jvnet/hudson/plugins/repositoryconnector/RepositoryConfiguration/config_de.properties
@@ -10,5 +10,7 @@ RepoManagerDescription=Gesetzt, falls die URL auf einen Verzeichnismanager zeigt
 Url=Url
 User=User
 Password=Passwort
+AllowDeploy=Allow Deploy
+AllowDeployDescription=checked if this repository allows manual deploy via Artifact Deployer post-build action
 AddNewRepo=Neues Verzeichnis hinzuf\u00fcgen
 Delete=L\u00f6schen

--- a/src/main/resources/org/jvnet/hudson/plugins/repositoryconnector/VersionParameterDefinition/index.jelly
+++ b/src/main/resources/org/jvnet/hudson/plugins/repositoryconnector/VersionParameterDefinition/index.jelly
@@ -1,15 +1,15 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
-	xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form"
-	xmlns:i="jelly:fmt" xmlns:p="/lib/hudson/project">
-	<f:entry title="${it.name}" description="${it.description}">
-		<div name="parameter" description="${it.description}">
-			<input type="hidden" name="name" value="${it.name}" />
+    xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form"
+    xmlns:i="jelly:fmt" xmlns:p="/lib/hudson/project">
+    <f:entry title="${it.name}" description="${it.description}">
+        <div name="parameter" description="${it.description}">
+            <input type="hidden" name="name" value="${it.name}" />
             <select name="value">
               <j:forEach var="value" items="${it.choices}">
                 <f:option selected="${it.value.isEmpty()}">${value}</f:option>
               </j:forEach>
             </select>
-		</div>
-	</f:entry>
+        </div>
+    </f:entry>
 </j:jelly>


### PR DESCRIPTION
Sadly doesn't look like auto-merge is applicable, due to the "Clean up whitespace inconsistencis" commit.
As for actually allowing the "Artifact Deploy" notifier:
It was unclear why the step was disabled, so to provide better management control, added a checkbox option to global config to specify if repo is "deployable". If no repos are found, then disables the notifier step (worth adding to plugin info page).
Also: fixes bug where the repo wouldn't be listed on job config page until page has been saved and re-config shows list.