### PR TITLE
[JENKINS-31206] Add checkbox to ArtifactDeployer to enable/disable POM upload with artifact

### DIFF
--- a/src/main/java/org/jvnet/hudson/plugins/repositoryconnector/Artifact.java
+++ b/src/main/java/org/jvnet/hudson/plugins/repositoryconnector/Artifact.java
@@ -20,15 +20,17 @@ public class Artifact implements Serializable {
     private final String version;
     private final String extension;
     private final String targetFileName;
+    private final Boolean uploadPOM;
 
    @DataBoundConstructor
-    public Artifact(String groupId, String artifactId, String classifier, String version, String extension, String targetFileName) {
+    public Artifact(String groupId, String artifactId, String classifier, String version, String extension, String targetFileName, Boolean uploadPOM) {
         this.groupId = groupId;
         this.artifactId = artifactId;
         this.classifier = classifier == null ? "" : classifier;
         this.extension = extension == null ? "jar" : extension;
         this.version = version;
         this.targetFileName = targetFileName;
+        this.uploadPOM = uploadPOM;
     }
 
     /**
@@ -71,6 +73,17 @@ public class Artifact implements Serializable {
      */
     public String getTargetFileName() {
         return targetFileName;
+    }
+
+    /**
+     * @return the uploadPOM
+     */
+    public boolean getUploadPOM() {
+        // Backwards compatibility: if null, config not updated: fallback to true
+        if (uploadPOM == null) {
+            return true;
+        }
+        return uploadPOM;
     }
 
     @Override

--- a/src/main/java/org/jvnet/hudson/plugins/repositoryconnector/aether/Aether.java
+++ b/src/main/java/org/jvnet/hudson/plugins/repositoryconnector/aether/Aether.java
@@ -230,7 +230,10 @@ public class Aether {
         RepositorySystemSession session = newSession();
 
         InstallRequest installRequest = new InstallRequest();
-        installRequest.addArtifact(artifact).addArtifact(pom);
+        installRequest.addArtifact(artifact);
+        if (pom != null) {
+            installRequest.addArtifact(pom);
+        }
 
         repositorySystem.install(session, installRequest);
     }
@@ -251,7 +254,9 @@ public class Aether {
 
         DeployRequest deployRequest = new DeployRequest();
         deployRequest.addArtifact(artifact);
-        deployRequest.addArtifact(pom);
+        if (pom != null) {
+            deployRequest.addArtifact(pom);
+        }
         deployRequest.setRepository(repoObj);
 
         repositorySystem.deploy(session, deployRequest);

--- a/src/main/resources/org/jvnet/hudson/plugins/repositoryconnector/ArtifactDeployer/config.jelly
+++ b/src/main/resources/org/jvnet/hudson/plugins/repositoryconnector/ArtifactDeployer/config.jelly
@@ -66,6 +66,10 @@
 					<f:textbox name="targetFileName" value="${artifact.targetFileName}" />
 				</f:entry>
 
+				<f:entry title="${%UploadPOM}" description="${%UploadPOMDescription}">
+					<f:checkbox name="uploadPOM" checked="${artifact.uploadPOM}" default="true" />
+				</f:entry>
+
 				<f:entry>
 					<div align="right">
 						<input type="button" value="${%AddArtifact}" class="repeatable-add show-if-last" />

--- a/src/main/resources/org/jvnet/hudson/plugins/repositoryconnector/ArtifactDeployer/config.properties
+++ b/src/main/resources/org/jvnet/hudson/plugins/repositoryconnector/ArtifactDeployer/config.properties
@@ -13,5 +13,7 @@ Version=Version
 Packaging=Packaging
 File=File
 FileDescription=the file to be deployed
+UploadPOM=Upload POM
+UploadPOMDescription=Upload POM file with artifact
 Add artifact=Add artifact
 Delete=Delete

--- a/src/main/resources/org/jvnet/hudson/plugins/repositoryconnector/ArtifactDeployer/config_de.properties
+++ b/src/main/resources/org/jvnet/hudson/plugins/repositoryconnector/ArtifactDeployer/config_de.properties
@@ -13,5 +13,7 @@ Version=Version
 Packaging=Paketierungsformat
 File=Datei
 FileDescription=Die hochzuladende Datei
+UploadPOM=Upload POM
+UploadPOMDescription=Upload POM file with artifact
 Add artifact=Artefakt hinzuf\u00fcgen
 Delete=L\u00f6schen

--- a/src/test/java/org/jvnet/hudson/plugins/repositoryconnector/ArtifactDownloadTest.java
+++ b/src/test/java/org/jvnet/hudson/plugins/repositoryconnector/ArtifactDownloadTest.java
@@ -31,7 +31,7 @@ public class ArtifactDownloadTest {
 
         FreeStyleProject p = j.createFreeStyleProject();
 
-        Artifact a = new Artifact("commons-logging", "commons-logging", null, "1.0.4", "jar", "myJar.jar");
+        Artifact a = new Artifact("commons-logging", "commons-logging", null, "1.0.4", "jar", "myJar.jar", true);
         ArtifactResolver resolver = new ArtifactResolver("target", Collections.singletonList(a), true, false, "always", null, "always", null);
         
         p.getBuildersList().add(resolver);
@@ -48,7 +48,7 @@ public class ArtifactDownloadTest {
 
         FreeStyleProject p = j.createFreeStyleProject();
 
-        Artifact a = new Artifact("commons-logging", "commons-logging", null, "1.0", "jar", "myJar.jar");
+        Artifact a = new Artifact("commons-logging", "commons-logging", null, "1.0", "jar", "myJar.jar", true);
         ArtifactResolver resolver = new ArtifactResolver(null, Collections.singletonList(a), true, false, "always", null, "always", null);
         
         p.getBuildersList().add(resolver);
@@ -63,7 +63,7 @@ public class ArtifactDownloadTest {
 
         FreeStyleProject p = j.createFreeStyleProject();
 
-        Artifact a = new Artifact("commons-logging", "commons-logging", null, "1.0.1", "jar", null);
+        Artifact a = new Artifact("commons-logging", "commons-logging", null, "1.0.1", "jar", null, true);
         ArtifactResolver resolver = new ArtifactResolver(null, Collections.singletonList(a), true, false, "always", null, "always", null);
         
         p.getBuildersList().add(resolver);
@@ -78,7 +78,7 @@ public class ArtifactDownloadTest {
 
         FreeStyleProject p = j.createFreeStyleProject();
 
-        Artifact a = new Artifact("${MY_ARTID}", "${MY_GROUP}", "${MY_CLASSIFIER}", "${MY_VERSION}", "${MY_EXT}", "${MY_FILE}");
+        Artifact a = new Artifact("${MY_ARTID}", "${MY_GROUP}", "${MY_CLASSIFIER}", "${MY_VERSION}", "${MY_EXT}", "${MY_FILE}", true);
         ArtifactResolver resolver = new ArtifactResolver(null, Collections.singletonList(a), true, false, "always", null, "always", null);
         
         p.getBuildersList().add(resolver);


### PR DESCRIPTION
Had a scenario where uploading similar packages to Nexus while using "classifier" to differentiate.
Since this always deployed the POM file with it, it'd fail out. And since didn't even need the POM file, figured may as well remove it.
My circumstances are quite unique, but providing PR regardless.
