### PR TITLE
[JENKINS-34537] Implement createValue(String) so that CLI can set the version

### DIFF
--- a/src/main/java/org/jvnet/hudson/plugins/repositoryconnector/VersionParameterDefinition.java
+++ b/src/main/java/org/jvnet/hudson/plugins/repositoryconnector/VersionParameterDefinition.java
@@ -113,8 +113,7 @@ public class VersionParameterDefinition extends
 
     @Override
     public ParameterValue createValue(String version) {
-        // this should never be called
-        throw new RuntimeException("Not implemented");
+        return new VersionParameterValue(groupid, artifactid, propertyName, version);
     }
 
     @Override

--- a/src/test/java/org/jvnet/hudson/plugins/repositoryconnector/ArtifactDownloadTest.java
+++ b/src/test/java/org/jvnet/hudson/plugins/repositoryconnector/ArtifactDownloadTest.java
@@ -35,7 +35,6 @@ public class ArtifactDownloadTest {
         ArtifactResolver resolver = new ArtifactResolver("target", Collections.singletonList(a), true, false, "always", null, "always", null);
         
         p.getBuildersList().add(resolver);
-        p.getBuildersList().add(new Shell("ls -ltr"));
         p.getBuildersList().add(new VerifyBuilder("target/myJar.jar"));
 
         j.assertBuildStatus(Result.SUCCESS, p.scheduleBuild2(0, new UserCause()).get());


### PR DESCRIPTION
When you use the jenkins CLI to invoke build request, it doesn't hit the other createValue method, it only hits this one which is unimplemented.
