### PR TITLE
Jenkins 2.3+ compatibility : fixed parameter name

### DIFF
--- a/src/main/java/org/jvnet/hudson/plugins/repositoryconnector/VersionParameterDefinition.java
+++ b/src/main/java/org/jvnet/hudson/plugins/repositoryconnector/VersionParameterDefinition.java
@@ -42,7 +42,7 @@ public class VersionParameterDefinition extends
     @DataBoundConstructor
     public VersionParameterDefinition(String repoid, String groupid,
             String artifactid, String propertyName, String description) {
-        super(groupid + "." + artifactid, description);
+        super((propertyName != null && !propertyName.isEmpty()) ? propertyName : groupid + "." + artifactid, description);
         this.repoid = repoid;
         this.groupid = groupid;
         this.artifactid = artifactid;


### PR DESCRIPTION
Since Jenkins 2.3, there is a protection that prevents repository-connector-plugin to create a variable while the job is being started.
https://wiki.jenkins-ci.org/display/SECURITY/Jenkins+Security+Advisory+2016-05-11 and more precisely : SECURITY-170 / CVE-2016-3721

This PR makes compatible this plugin to Jenkins 2.3 and displays correctly the property name (when defined) instead of "group.artifact"
