### PR TITLE
JENKINS-50293 Repository Connector Plugin does not use Jenkins config…

### DIFF
--- a/src/test/java/org/jvnet/hudson/plugins/repositoryconnector/aether/AetherTest.java
+++ b/src/test/java/org/jvnet/hudson/plugins/repositoryconnector/aether/AetherTest.java
@@ -1,31 +1,22 @@
 package org.jvnet.hudson.plugins.repositoryconnector.aether;
 
-import org.junit.Before;
 import org.junit.Test;
-
-import java.io.File;
 
 import static org.junit.Assert.assertEquals;
 
 public class AetherTest {
 
-    private Aether sut;
-
-    @Before
-    public void setup() {
-        sut = new Aether(new File("jenkinstest"), System.out, false);
-    }
-
     @Test
     public void convertGivenNonHttpProxySettings() throws Exception {
 
-        String result = sut.convertHudsonNonProxyToJavaNonProxy("localhost\n*.google.com\n\napple.com");
+        String result = Aether.convertHudsonNonProxyToJavaNonProxy("localhost\n*.google.com\n\napple.com");
 
         assertEquals("New lines should be replaced", result, "localhost|*.google.com|apple.com");
     }
 
     @Test
     public void convertGivenNullNonHttpProxySettings() throws Exception {
-        assertEquals("New lines should be replaced", sut.convertHudsonNonProxyToJavaNonProxy(null), "");
+        assertEquals("New lines should be replaced", Aether.convertHudsonNonProxyToJavaNonProxy(null), "");
     }
+
 }


### PR DESCRIPTION
As per aether's DefaultRepositorySystemSession.setProxySelector javadoc: **Note that this selector is not used for remote repositories which are passed as request parameters to the repository system, those repositories are supposed to have their proxy (if any) already set.**
The PR ensures the proxy is set to RemoteRepository objects on Aether instance initialization