### PR TITLE
JENKINS-60861 - Default configuration to Maven Central without HTTPS no longer work

### DIFF
--- a/src/main/java/org/jvnet/hudson/plugins/repositoryconnector/RepositoryConfiguration.java
+++ b/src/main/java/org/jvnet/hudson/plugins/repositoryconnector/RepositoryConfiguration.java
@@ -32,7 +32,7 @@ public class RepositoryConfiguration extends GlobalConfiguration implements Seri
 
     private static final Map<String, Repository> DEFAULT_REPOS = new HashMap<String, Repository>();
     static {
-        DEFAULT_REPOS.put("central", new Repository("central", "default", "http://repo1.maven.org/maven2", null, null, false));
+        DEFAULT_REPOS.put("central", new Repository("central", "default", "https://repo1.maven.org/maven2", null, null, false));
     }
 
     private final Map<String, Repository> repos = new HashMap<String, Repository>();

--- a/src/main/resources/org/jvnet/hudson/plugins/repositoryconnector/RepositoryConfiguration/config.properties
+++ b/src/main/resources/org/jvnet/hudson/plugins/repositoryconnector/RepositoryConfiguration/config.properties
@@ -1,6 +1,6 @@
 ArtifactResolver=Artifact Resolver
 Repositories=Repositories
-RepositoriesDescription=Repositories to download the artifacts from (e.g. maven central 'http://repo1.maven.org/maven2')
+RepositoriesDescription=Repositories to download the artifacts from (e.g. maven central 'https://repo1.maven.org/maven2')
 LocalRepository=Local Repository
 LocalRepositoryDescription=local repository on master (falls back to 'java.io.tmpdir')
 RepoId=Repo Id

--- a/src/main/resources/org/jvnet/hudson/plugins/repositoryconnector/RepositoryConfiguration/config_de.properties
+++ b/src/main/resources/org/jvnet/hudson/plugins/repositoryconnector/RepositoryConfiguration/config_de.properties
@@ -1,6 +1,6 @@
 ArtifactResolver=Artefakt Aufl\u00f6sung
 Repositories=Verzeichnisse
-RepositoriesDescription=Verzeichnisse aus denen Artefakte heruntergeladen werden (z.B. Maven Central 'http://repo1.maven.org/maven2')
+RepositoriesDescription=Verzeichnisse aus denen Artefakte heruntergeladen werden (z.B. Maven Central 'https://repo1.maven.org/maven2')
 LocalRepository=Lokales Verzeichnis
 LocalRepositoryDescription=Lokales verzeichnis auf dem Hauptknoten (wenn leer, dann 'java.io.tmpdir')
 RepoId=Verzeichnisname


### PR DESCRIPTION
Changing DEFAULT_REPOS from http to https.