### PR TITLE
Added possibility to not send updated value in the form of Use current

### DIFF
--- a/src/main/java/org/jvnet/hudson/plugins/repositoryconnector/VersionParameterValue.java
+++ b/src/main/java/org/jvnet/hudson/plugins/repositoryconnector/VersionParameterValue.java
@@ -17,6 +17,7 @@ public class VersionParameterValue extends StringParameterValue {
     private final String groupid;
     private final String artifactid;
     private final String propertyName;
+    private final boolean useCurrent;
 
     public String getGroupid() {
         return groupid;
@@ -30,12 +31,15 @@ public class VersionParameterValue extends StringParameterValue {
         return propertyName;
     }
 
+    public boolean isUseCurrent() { return useCurrent; }
+
     @DataBoundConstructor
-    public VersionParameterValue(String groupid, String artifactid, String propertyName, String version) {
+    public VersionParameterValue(String groupid, String artifactid, String propertyName, String version, boolean useCurrent) {
         super((propertyName != null && !propertyName.isEmpty()) ? propertyName : groupid + "." + artifactid, version);
         this.groupid = groupid;
         this.artifactid = artifactid;
         this.propertyName = propertyName;
+        this.useCurrent = useCurrent;
     }
 
     @Override
@@ -53,6 +57,8 @@ public class VersionParameterValue extends StringParameterValue {
         sb.append(propertyName);
         sb.append(", version=");
         sb.append(getValue());
+        sb.append(", useCurrent=");
+        sb.append(String.valueOf(useCurrent));
         sb.append(']');
         return sb.toString();
     }

--- a/src/main/resources/org/jvnet/hudson/plugins/repositoryconnector/VersionParameterDefinition/config.jelly
+++ b/src/main/resources/org/jvnet/hudson/plugins/repositoryconnector/VersionParameterDefinition/config.jelly
@@ -21,4 +21,8 @@
     <f:entry title="${%Description}">
         <f:textarea field="description" value="${instance.description}" />
     </f:entry>
+    <f:entry title="${%useCurrent}" field="useCurrent">
+      <f:checkbox/>
+    </f:entry>
+
 </j:jelly>

--- a/src/main/resources/org/jvnet/hudson/plugins/repositoryconnector/VersionParameterDefinition/config.properties
+++ b/src/main/resources/org/jvnet/hudson/plugins/repositoryconnector/VersionParameterDefinition/config.properties
@@ -3,3 +3,5 @@ GroupId=Group Id
 ArtifactId=Artifact Id
 Description=Description
 PropertyName=Property Name
+useCurrent=Use current version
+

--- a/src/main/resources/org/jvnet/hudson/plugins/repositoryconnector/VersionParameterDefinition/config_de.properties
+++ b/src/main/resources/org/jvnet/hudson/plugins/repositoryconnector/VersionParameterDefinition/config_de.properties
@@ -3,3 +3,4 @@ GroupId=Gruppen Id
 ArtifactId=Artefakt Id
 Description=Beschreibung
 PropertyName=Attributname
+useCurrent=Aktuelle version benutzen

--- a/src/main/resources/org/jvnet/hudson/plugins/repositoryconnector/VersionParameterDefinition/help.html
+++ b/src/main/resources/org/jvnet/hudson/plugins/repositoryconnector/VersionParameterDefinition/help.html
@@ -7,6 +7,7 @@
         <li>Group Id - the group id of the artifact to resolve</li>
         <li>Artifact Id - the artifact id of the artifact to resolve</li>
         <li>Description - a description for what the artifact is used for</li>
+        <li>Use current version - Provide an option that sends "CURRENT" to the build variables</li>
     </ul>
     <b>This parameter type does not support a default value - therefore, this type should not be used in a scheduled job!</b>
 </div>


### PR DESCRIPTION
Problem: 
In 1.1.3 the implementation (not finished) enabled RELEASE to submit the build value RELEASE. After this was corrected, the value of the release tag was submitted instead. However in our project we used the parametrized build feature to select a combination of artefacts to represent a larger release, and then update a pom file with these references. We used "RELEASE" to simply say "don't change anything, use what's in the current version of the pom". However this is wrong on all accounts, that is not how maven, nexus etc uses releases (that is also heading to be deprecated) of course.

Solution proposal (Implemented in the PR):
Introduce another special tag called CURRENT that can be enabled with a checkbox. Selecting the checkbox will put the static CURRENT value on top and provide it for the artefact is selected. 

Other: 
I'm not sure the naming is correct, I'm not satisfied with it and would be happy for a better suggestion.
I've thought about "CURRENT", "IGNORE", "DONTCHANGE", "USECURRENT", "UNCHANGED", "FIXED" etc.

![repo1](https://user-images.githubusercontent.com/527357/96570638-e3d4cd00-12ca-11eb-8d19-6a44dd68b2f1.png)
![repo2](https://user-images.githubusercontent.com/527357/96570645-e59e9080-12ca-11eb-8735-1b1e87f371ea.png)
![repo4](https://user-images.githubusercontent.com/527357/96570653-e800ea80-12ca-11eb-8c5a-b28684ca267d.png)
![repo3](https://user-images.githubusercontent.com/527357/96570664-eafbdb00-12ca-11eb-9e9c-b9015bddbd4a.png)


