### PR TITLE
[JENKINS-65202] The global configuration for the snapshot update policy is never applied

### DIFF
--- a/src/main/java/org/jvnet/hudson/plugins/repositoryconnector/aether/RemoteRepositoryFactory.java
+++ b/src/main/java/org/jvnet/hudson/plugins/repositoryconnector/aether/RemoteRepositoryFactory.java
@@ -58,7 +58,7 @@ class RemoteRepositoryFactory {
     }
 
     private void addSnapshotPolicy(Builder builder, Repository repository) {
-        builder.setReleasePolicy(createRepositoryPolicy(repository.isEnableSnapshotRepository(), repository.getSnapshotRepository()));
+        builder.setSnapshotPolicy(createRepositoryPolicy(repository.isEnableSnapshotRepository(), repository.getSnapshotRepository()));
     }
 
     private RemoteRepository createRemoteRepository(Repository repository) {


### PR DESCRIPTION
See JIRA for details:
https://issues.jenkins.io/browse/JENKINS-65202