### PR TITLE
[JENKINS-66327] Prepare Repository Connector for core Guava upgrade

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.15</version>
+    <version>4.24</version>
     <relativePath />
   </parent>
 
@@ -53,14 +53,14 @@
   <repositories>
     <repository>
       <id>repo.jenkins-ci.org</id>
-      <url>http://repo.jenkins-ci.org/public/</url>
+      <url>https://repo.jenkins-ci.org/public/</url>
     </repository>
   </repositories>
 
   <pluginRepositories>
     <pluginRepository>
       <id>repo.jenkins-ci.org</id>
-      <url>http://repo.jenkins-ci.org/public/</url>
+      <url>https://repo.jenkins-ci.org/public/</url>
     </pluginRepository>
   </pluginRepositories>
 

--- a/src/main/java/org/jvnet/hudson/plugins/repositoryconnector/util/FilePathUtils.java
+++ b/src/main/java/org/jvnet/hudson/plugins/repositoryconnector/util/FilePathUtils.java
@@ -4,7 +4,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
 
-import com.google.common.io.Files;
+import java.nio.file.Files;
 
 import hudson.FilePath;
 
@@ -22,7 +22,7 @@ public class FilePathUtils {
     }
 
     static OutputStream createOutputStream(File file) throws IOException {
-        return Files.newOutputStreamSupplier(file).getOutput();
+        return Files.newOutputStream(file.toPath());
     }
 
     static File createTempFile(String prefix, String suffix) throws IOException {

--- a/src/test/java/org/jvnet/hudson/plugins/repositoryconnector/AbstractArtifactTest.java
+++ b/src/test/java/org/jvnet/hudson/plugins/repositoryconnector/AbstractArtifactTest.java
@@ -8,7 +8,7 @@ import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.google.common.io.Files;
+import java.nio.file.Files;
 
 import org.junit.After;
 import org.junit.Before;
@@ -54,7 +54,7 @@ abstract class AbstractArtifactTest {
         when(mockListener.getLogger()).thenReturn(mockPrintStream);
 
         artifacts = new ArrayList<>();
-        workspace = new FilePath(Files.createTempDir());
+        workspace = new FilePath(Files.createTempDirectory(null).toFile());
     }
 
     protected File getTestJar() throws URISyntaxException {

--- a/src/test/java/org/jvnet/hudson/plugins/repositoryconnector/aether/AetherIT.java
+++ b/src/test/java/org/jvnet/hudson/plugins/repositoryconnector/aether/AetherIT.java
@@ -9,7 +9,7 @@ import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.Collection;
 
-import com.google.common.io.Files;
+import java.nio.file.Files;
 
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -89,8 +89,8 @@ public class AetherIT {
     }
 
     @BeforeClass
-    public static void startup() {
-        localRepository = Files.createTempDir();
+    public static void startup() throws IOException {
+        localRepository = Files.createTempDirectory(null).toFile();
     }
 
     @AfterClass


### PR DESCRIPTION
See [JENKINS-66327](https://issues.jenkins.io/browse/JENKINS-66327) and [JENKINS-65988](https://issues.jenkins.io/browse/JENKINS-65988). Jenkins core is using [Guava 11.0.1](https://github.com/google/guava/releases/tag/v11.0.1), which was released on January 9, 2012. Jenkins core would like to upgrade to [Guava 30.1.1](https://github.com/google/guava/releases/tag/v30.1.1), which was released on March 19, 2021. Plugins must be prepared to be compatible with both Guava 11.0.1 and Guava 30.1.1 in advance of this core transition.

In particular, this plugin has been identified as using the `com.google.common.io.Files#newOutputStreamSupplier` method, which existed in Guava [11.0.1](https://guava.dev/releases/11.0.1/api/docs/com/google/common/io/Files.html) but was [removed in later versions](https://guava.dev/releases/snapshot-jre/api/docs/com/google/common/io/Files.html).

To facilitate the Jenkins core transition, this plugin must be prepared and released such that it works with both Guava 11.0.1 and latest. In this PR we remove all usages of Guava in this plugin and rewrite them with native Java Platform functionality.