### PR TITLE
Removed 1 unnecessary stubbing in AbstractArtifactTest.java

### DIFF
--- a/src/test/java/org/jvnet/hudson/plugins/repositoryconnector/SecondAbstractArtifactTest.java
+++ b/src/test/java/org/jvnet/hudson/plugins/repositoryconnector/SecondAbstractArtifactTest.java
@@ -1,0 +1,72 @@
+package org.jvnet.hudson.plugins.repositoryconnector;
+
+import static org.mockito.Mockito.when;
+
+import java.io.File;
+import java.io.PrintStream;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.List;
+
+import java.nio.file.Files;
+
+import org.junit.After;
+import org.junit.Before;
+import org.jvnet.hudson.plugins.repositoryconnector.aether.Aether;
+import org.jvnet.hudson.plugins.repositoryconnector.util.TokenMacroExpander;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import hudson.FilePath;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+
+abstract class SecondAbstractArtifactTest {
+
+    protected List<Artifact> artifacts;
+
+    @Mock
+    protected Aether mockAether;
+
+    @Mock
+    protected TokenMacroExpander mockExpander;
+
+    @Mock
+    protected TaskListener mockListener;
+
+    @Mock
+    protected PrintStream mockPrintStream;
+
+    @Mock
+    protected Run<?, ?> mockRun;
+
+    protected FilePath workspace;
+
+    @After
+    public void after() throws Exception {
+        workspace.deleteRecursive();
+    }
+
+    @Before
+    public void before() throws Exception {
+        MockitoAnnotations.initMocks(this);
+        
+        artifacts = new ArrayList<>();
+        workspace = new FilePath(Files.createTempDirectory(null).toFile());
+    }
+
+    protected File getTestJar() throws URISyntaxException {
+        return new File(this.getClass().getResource("test.jar").toURI());
+    }
+
+    @SuppressWarnings("unused")
+    protected Artifact createArtifact(boolean failOnError) throws Exception {
+        Artifact artifact = new Artifact("org.junit.jupiter", "junit-jupiter", "5.7.0");
+        artifact.setFailOnError(failOnError);
+
+        artifacts.add(artifact);
+        when(mockExpander.expand(artifact)).thenReturn(artifact);
+
+        return artifact;
+    }
+}

--- a/src/test/java/org/jvnet/hudson/plugins/repositoryconnector/VersionParameterDefinitionTest.java
+++ b/src/test/java/org/jvnet/hudson/plugins/repositoryconnector/VersionParameterDefinitionTest.java
@@ -15,7 +15,7 @@ import org.mockito.Mock;
 
 import hudson.model.Item;
 
-public class VersionParameterDefinitionTest extends AbstractArtifactTest {
+public class VersionParameterDefinitionTest extends SecondAbstractArtifactTest {
 
     @Mock
     private Item mockItem;


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
In our analysis of the project, we observed that 
1) the stubbing in the `AbstractArtifactTest.before` is created but never executed by 3 tests: `VersionParameterDefinitionTest.testGetVersions`, `VersionParameterDefinitionTest.testGetVersionParameterValue`, and `VersionParameterDefinitionTest.testEscapeInputs`.

Unnecessary stubbings are stubbed method calls that were never realized during test execution. Mockito recommends to remove unnecessary stubbings (https://www.javadoc.io/doc/org.mockito/mockito-core/latest/org/mockito/exceptions/misusing/UnnecessaryStubbingException.html).

We propose below a solution to remove the unnecessary stubbing.